### PR TITLE
Add multi-criteria route planner and controller tests

### DIFF
--- a/Route_Optimization_Subproblem/controller.py
+++ b/Route_Optimization_Subproblem/controller.py
@@ -1,0 +1,94 @@
+"""Transport orchestration utilities for the Route Optimization subproblem."""
+from __future__ import annotations
+
+from typing import Any, List, Optional
+
+from .route_planner import Node, RoutePlanner
+
+
+class TransportController:
+    """Coordinate transport operations and trigger replanning when needed."""
+
+    def __init__(self, planner: RoutePlanner, communicator: Any) -> None:
+        """Store dependencies and initialize internal state."""
+        self.planner = planner
+        self.communicator = communicator
+        self.current_route: List[Node] = []
+        self.current_index: int = 0
+        self.destination: Optional[Node] = None
+        self.remaining_distance: float = 0.0
+        self.remaining_risk: float = 0.0
+
+    def start(self, start: Node, end: Node, max_distance: float, max_risk: float) -> None:
+        """Plan an initial route and initialize tracking information."""
+        self.destination = end
+        self.current_route = self.planner.compute_route(start, end, max_distance, max_risk)
+        self.current_index = 0
+        self.remaining_distance = max_distance
+        # Account for the hazard of the starting node immediately.
+        self.remaining_risk = max_risk - self.planner.hazard_map.get(start, 0.0)
+
+    def step(self) -> Optional[Node]:
+        """Advance to the next node on the current route.
+
+        Returns ``None`` if the destination has already been reached, otherwise
+        returns the newly reached node.
+        """
+        if self.current_index + 1 < len(self.current_route):
+            previous_node = self.current_route[self.current_index]
+            self.current_index += 1
+            new_node = self.current_route[self.current_index]
+            self._update_consumed_budgets(previous_node, new_node)
+            return new_node
+        return None
+
+    def sensor_event(self, current_node: Node, event: str) -> None:
+        """Handle a sensor anomaly at ``current_node`` by attempting to replan.
+
+        When replanning we keep the already consumed distance/risk budgets and
+        request a fresh path from the planner. If no viable route remains we
+        notify via ``communicator.send_alert``.
+        """
+        if self.destination is None:
+            return
+
+        # Remaining budgets exclude the hazard of the current node because it
+        # has already been accounted for. Add it back before replanning so the
+        # planner can count it once more when starting from ``current_node``.
+        hazard_current = self.planner.hazard_map.get(current_node, 0.0)
+        adjusted_risk_budget = self.remaining_risk + hazard_current
+
+        try:
+            new_route = self.planner.compute_route(
+                current_node,
+                self.destination,
+                self.remaining_distance,
+                adjusted_risk_budget,
+            )
+        except ValueError:
+            message = (
+                f"Replanning failed from {current_node} due to event '{event}'. "
+                "No feasible route remains."
+            )
+            self.communicator.send_alert(message)
+            return
+
+        # Replanning succeeded: reset the route starting from the current node.
+        self.current_route = new_route
+        self.current_index = 0
+        # Restore budgets so that the hazard of the current node remains
+        # accounted for exactly once.
+        self.remaining_risk = adjusted_risk_budget - hazard_current
+
+    def _update_consumed_budgets(self, previous: Node, current: Node) -> None:
+        """Update the remaining budgets after traversing an edge."""
+        distance_cost = self._edge_distance(previous, current)
+        self.remaining_distance -= distance_cost
+        self.remaining_risk -= self.planner.hazard_map.get(current, 0.0)
+
+    def _edge_distance(self, source: Node, target: Node) -> float:
+        """Return the distance cost between ``source`` and ``target``."""
+        for neighbor, distance in self.planner.graph.get(source, []):
+            if neighbor == target:
+                return float(distance)
+        raise ValueError(f"No edge between {source} and {target}")

--- a/Route_Optimization_Subproblem/route_planner.py
+++ b/Route_Optimization_Subproblem/route_planner.py
@@ -1,0 +1,157 @@
+"""Route planning utilities for the Route Optimization subproblem."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Tuple, Optional
+import heapq
+
+Node = Any
+
+
+@dataclass(frozen=True)
+class _State:
+    """Container describing a search state for path reconstruction."""
+    node: Node
+    distance: float
+    risk: float
+    parent_id: Optional[int]
+
+
+class RoutePlanner:
+    """Plan constrained routes on a weighted graph with hazard costs."""
+
+    def __init__(
+        self,
+        graph: Dict[Node, List[Tuple[Node, float]]],
+        hazard_map: Dict[Node, float],
+    ) -> None:
+        """Store the road network and associated hazard costs.
+
+        Args:
+            graph: Adjacency list mapping each node to a list of tuples of the
+                form ``(neighbor, distance_cost)``.
+            hazard_map: Mapping of each node to the hazard/risk cost incurred
+                when visiting the node.
+        """
+        self.graph = graph
+        self.hazard_map = hazard_map
+
+    def _get_hazard(self, node: Node) -> float:
+        """Return the hazard for ``node`` (defaults to zero if unknown)."""
+        return float(self.hazard_map.get(node, 0.0))
+
+    def compute_route(
+        self,
+        start: Node,
+        end: Node,
+        max_distance: float,
+        max_risk: float,
+    ) -> List[Node]:
+        """Compute a path obeying distance and risk budgets.
+
+        A multi-criteria label-setting search (variant of Dijkstra) is used to
+        simultaneously track the total distance and accumulated risk. We keep a
+        set of non-dominated states per node. A state ``s1`` dominates ``s2`` if
+        its distance and risk are both less-than-or-equal to ``s2``. Dominated
+        states can never lead to a better solution and are therefore pruned.
+        The priority queue is keyed by ``(risk, distance)`` to ensure that the
+        first time we pop the destination node we have found the optimal route
+        (minimal risk, then minimal distance).
+        """
+        if max_distance < 0 or max_risk < 0:
+            raise ValueError("Budgets must be non-negative")
+
+        start_hazard = self._get_hazard(start)
+        if start == end:
+            if start_hazard <= max_risk:
+                return [start]
+            raise ValueError("No feasible route")
+
+        # Priority queue entries: (risk, distance, state_id)
+        priority_queue: List[Tuple[float, float, int]] = []
+        state_id_counter = 0
+        states: Dict[int, _State] = {}
+        per_node_states: Dict[Node, List[int]] = {}
+
+        # Initialize with the starting node.
+        initial_state = _State(node=start, distance=0.0, risk=start_hazard, parent_id=None)
+        states[state_id_counter] = initial_state
+        per_node_states[start] = [state_id_counter]
+        heapq.heappush(priority_queue, (initial_state.risk, initial_state.distance, state_id_counter))
+
+        # Track which states are currently valid (non-dominated).
+        valid_states = {state_id_counter}
+
+        while priority_queue:
+            current_risk, current_distance, state_id = heapq.heappop(priority_queue)
+            if state_id not in valid_states:
+                # Skip stale entries that were dominated later on.
+                continue
+
+            current_state = states[state_id]
+            node = current_state.node
+
+            if current_risk > max_risk or current_distance > max_distance:
+                continue
+
+            if node == end:
+                # Optimal solution reached due to queue ordering.
+                return self._reconstruct_path(state_id, states)
+
+            for neighbor, edge_distance in self.graph.get(node, []):
+                new_distance = current_state.distance + float(edge_distance)
+                if new_distance > max_distance:
+                    continue
+
+                neighbor_hazard = self._get_hazard(neighbor)
+                new_risk = current_state.risk + neighbor_hazard
+                if new_risk > max_risk:
+                    continue
+
+                # Dominance check: ensure the new state is not worse than an
+                # existing state for the same neighbor.
+                neighbor_state_ids = per_node_states.setdefault(neighbor, [])
+                dominated = False
+                dominated_ids: List[int] = []
+                for existing_id in neighbor_state_ids:
+                    existing_state = states[existing_id]
+                    if existing_state.distance <= new_distance and existing_state.risk <= new_risk:
+                        dominated = True
+                        break
+                    if new_distance <= existing_state.distance and new_risk <= existing_state.risk:
+                        dominated_ids.append(existing_id)
+
+                if dominated:
+                    continue
+
+                # Remove any states that are dominated by the new state.
+                if dominated_ids:
+                    for dominated_id in dominated_ids:
+                        if dominated_id in valid_states:
+                            valid_states.remove(dominated_id)
+                    neighbor_state_ids[:] = [sid for sid in neighbor_state_ids if sid not in dominated_ids]
+
+                state_id_counter += 1
+                new_state = _State(
+                    node=neighbor,
+                    distance=new_distance,
+                    risk=new_risk,
+                    parent_id=state_id,
+                )
+                states[state_id_counter] = new_state
+                neighbor_state_ids.append(state_id_counter)
+                valid_states.add(state_id_counter)
+                heapq.heappush(priority_queue, (new_state.risk, new_state.distance, state_id_counter))
+
+        raise ValueError("No feasible route")
+
+    def _reconstruct_path(self, state_id: int, states: Dict[int, _State]) -> List[Node]:
+        """Reconstruct the path ending at ``state_id``."""
+        path: List[Node] = []
+        current_id: Optional[int] = state_id
+        while current_id is not None:
+            state = states[current_id]
+            path.append(state.node)
+            current_id = state.parent_id
+        path.reverse()
+        return path

--- a/Route_Optimization_Subproblem/tests/test_controller.py
+++ b/Route_Optimization_Subproblem/tests/test_controller.py
@@ -1,0 +1,67 @@
+"""Tests for :mod:`Route_Optimization_Subproblem.controller`."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+import pytest
+
+from Route_Optimization_Subproblem.controller import TransportController
+from Route_Optimization_Subproblem.route_planner import RoutePlanner
+
+
+def build_planner() -> RoutePlanner:
+    graph = {
+        "A": [("B", 5.0)],
+        "B": [("C", 5.0), ("D", 2.0)],
+        "C": [("E", 2.0)],
+        "D": [("E", 5.0)],
+        "E": [],
+    }
+    hazard_map = {"A": 1.0, "B": 2.0, "C": 5.0, "D": 1.0, "E": 1.0}
+    return RoutePlanner(graph, hazard_map)
+
+
+@dataclass
+class DummyCommunicator:
+    alerts: List[str] = field(default_factory=list)
+
+    def send_alert(self, message: str) -> None:
+        self.alerts.append(message)
+
+
+def test_sensor_event_triggers_replan_successfully() -> None:
+    planner = build_planner()
+    communicator = DummyCommunicator()
+    controller = TransportController(planner, communicator)
+
+    controller.start("A", "E", max_distance=20.0, max_risk=15.0)
+    # Move from A to B.
+    assert controller.step() == "B"
+
+    # Increase the hazard for D so the planner should now choose C instead.
+    planner.hazard_map["D"] = 10.0
+    controller.sensor_event("B", "hazard_increase")
+
+    assert controller.current_route == ["B", "C", "E"]
+    assert controller.current_index == 0
+    # Budgets should remain unchanged by replanning.
+    assert pytest.approx(controller.remaining_risk, rel=1e-6) == 12.0
+    assert pytest.approx(controller.remaining_distance, rel=1e-6) == 15.0
+    assert communicator.alerts == []
+
+
+def test_sensor_event_sends_alert_when_no_route() -> None:
+    planner = build_planner()
+    communicator = DummyCommunicator()
+    controller = TransportController(planner, communicator)
+
+    controller.start("A", "E", max_distance=12.0, max_risk=6.0)
+    assert controller.step() == "B"
+
+    # Tighten risk budget to ensure infeasibility.
+    controller.remaining_risk = -1.0
+    controller.sensor_event("B", "blocked")
+
+    assert communicator.alerts
+    assert "blocked" in communicator.alerts[0]

--- a/Route_Optimization_Subproblem/tests/test_route_planner.py
+++ b/Route_Optimization_Subproblem/tests/test_route_planner.py
@@ -1,0 +1,52 @@
+"""Unit tests for :mod:`Route_Optimization_Subproblem.route_planner`."""
+from __future__ import annotations
+
+import pytest
+
+from Route_Optimization_Subproblem.route_planner import RoutePlanner
+
+
+@pytest.fixture
+def sample_graph() -> RoutePlanner:
+    graph = {
+        "A": [("B", 2.0), ("C", 2.0)],
+        "B": [("D", 3.0)],
+        "C": [("D", 3.0)],
+        "D": [],
+    }
+    hazard_map = {"A": 1.0, "B": 2.0, "C": 1.0, "D": 1.0}
+    return RoutePlanner(graph=graph, hazard_map=hazard_map)
+
+
+def test_compute_route_prefers_lower_risk(sample_graph: RoutePlanner) -> None:
+    route = sample_graph.compute_route("A", "D", max_distance=10.0, max_risk=10.0)
+    assert route == ["A", "C", "D"]
+
+
+def test_compute_route_breaks_risk_ties_with_distance() -> None:
+    graph = {
+        "A": [("B", 2.0), ("C", 4.0)],
+        "B": [("D", 2.0)],
+        "C": [("D", 2.0)],
+        "D": [],
+    }
+    hazard_map = {"A": 1.0, "B": 2.0, "C": 2.0, "D": 1.0}
+    planner = RoutePlanner(graph, hazard_map)
+    route = planner.compute_route("A", "D", max_distance=10.0, max_risk=10.0)
+    # Both paths have identical risk (1 + 2 + 1 == 1 + 2 + 1) but the
+    # A->B->D option is shorter.
+    assert route == ["A", "B", "D"]
+
+
+def test_start_equals_end(sample_graph: RoutePlanner) -> None:
+    assert sample_graph.compute_route("A", "A", 5.0, 5.0) == ["A"]
+
+
+def test_no_feasible_route_due_to_risk(sample_graph: RoutePlanner) -> None:
+    with pytest.raises(ValueError, match="No feasible route"):
+        sample_graph.compute_route("A", "D", max_distance=10.0, max_risk=2.0)
+
+
+def test_negative_budget_raises(sample_graph: RoutePlanner) -> None:
+    with pytest.raises(ValueError):
+        sample_graph.compute_route("A", "D", max_distance=-1.0, max_risk=5.0)


### PR DESCRIPTION
## Summary
- implement a multi-criteria Dijkstra route planner with hazard-aware dominance pruning
- add a transport controller that supports replanning under sensor events
- create unit tests for planner behaviour and controller replanning/alert handling

## Testing
- `python -m pytest Route_Optimization_Subproblem/tests`


------
https://chatgpt.com/codex/tasks/task_e_68e14e42134083309a39c359a9be21e2